### PR TITLE
Display actual team names instead of codes

### DIFF
--- a/src/app/first-time-login/page.tsx
+++ b/src/app/first-time-login/page.tsx
@@ -7,11 +7,11 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { BookMarked, CheckCircle, XCircle, ArrowLeft, Eye, EyeOff } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { verifyEmailExists } from '@/lib/db';
+import { verifyEmailExists, getTeam } from '@/lib/db';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
 import { useToast } from '@/hooks/use-toast';
-import type { User } from '@/lib/types';
+import type { User, Team } from '@/lib/types';
 
 export default function FirstTimeLoginPage() {
   const [step, setStep] = React.useState<'email' | 'password'>('email');
@@ -20,6 +20,7 @@ export default function FirstTimeLoginPage() {
   const [confirmPassword, setConfirmPassword] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
   const [user, setUser] = React.useState<User | null>(null);
+  const [team, setTeam] = React.useState<Team | null>(null);
   const [showPassword, setShowPassword] = React.useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = React.useState(false);
   const router = useRouter();
@@ -59,6 +60,17 @@ export default function FirstTimeLoginPage() {
         
         console.log('User found:', foundUser);
         setUser(foundUser);
+        
+        // Load team data if user has a teamId
+        if (foundUser.teamId) {
+          try {
+            const teamData = await getTeam(foundUser.teamId);
+            setTeam(teamData);
+          } catch (error) {
+            console.error('Error loading team data:', error);
+          }
+        }
+        
         setStep('password');
         toast({
           title: 'User Found!',
@@ -216,7 +228,7 @@ export default function FirstTimeLoginPage() {
                   </div>
                   <p className="text-sm text-muted-foreground mt-1">{email}</p>
                   {user?.teamId && (
-                    <p className="text-sm text-muted-foreground">Team: {user.teamId}</p>
+                    <p className="text-sm text-muted-foreground">Team: {team?.name || user.teamId}</p>
                   )}
                 </div>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -691,7 +691,7 @@ export default function SettingsPage() {
               {/* Add Team Member */}
               {isUserAdminState && currentUser?.teamId && (
                 <div className="space-y-4 p-6 bg-background/50 backdrop-blur-sm rounded-xl border border-border/30">
-                  <Label className="text-lg font-semibold">Add Team Member to {currentUser?.teamId?.toUpperCase()}</Label>
+                  <Label className="text-lg font-semibold">Add Team Member to {teams.find(t => t.id === currentUser?.teamId)?.name || currentUser?.teamId?.toUpperCase()}</Label>
                   <form onSubmit={handleAddMember} className="flex gap-3">
                     <Input
                       type="email"
@@ -711,7 +711,7 @@ export default function SettingsPage() {
               {/* Team Members List */}
               <div className="space-y-4">
                 <Label className="text-lg font-semibold">
-                  Team {currentUser?.teamId?.toUpperCase()} Members ({teamMembers.length})
+                  {teams.find(t => t.id === currentUser?.teamId)?.name || currentUser?.teamId?.toUpperCase()} Members ({teamMembers.length})
                 </Label>
                 <div className="space-y-3">
                   {teamMembers.map((member) => (


### PR DESCRIPTION
Display actual team names instead of IDs on login and settings pages.

Previously, team IDs were shown, making it difficult for users to identify their teams. This change fetches and displays the human-readable team name, falling back to the ID if the name is unavailable.