### PR TITLE
Implement super user prompt management

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -33,7 +33,7 @@
       ".write": "auth != null",
       "$promptId": {
         ".read": "(auth != null && data.child('sharing').val() == 'global') || (auth != null && data.child('createdBy').val() == auth.uid) || (auth != null && data.child('sharing').val() == 'team' && data.child('teamId').exists() && root.child('users').child(auth.uid).child('teamId').val() == data.child('teamId').val()) || (auth != null && root.child('users').child(auth.uid).child('role').val() == 'super_user')",
-        ".write": "auth != null && ((!data.exists() || data.child('createdBy').val() == auth.uid) || root.child('users').child(auth.uid).child('role').val() == 'super_user')"
+        ".write": "auth != null && ((!data.exists()) || root.child('users').child(auth.uid).child('role').val() == 'super_user')"
       }
     }
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ import {
   getPromptsBySharing 
 } from '@/lib/db';
 import { getCurrentUser } from '@/lib/auth';
-import { isSuperUser } from '@/lib/permissions';
+import { isSuperUser, canEditPrompt, canDeletePrompt } from '@/lib/permissions';
 import type { User } from '@/lib/types';
 
 type SharingScope = 'private' | 'team' | 'community';
@@ -116,6 +116,13 @@ export default function PromptKeeperPage() {
       await updatePrompt(updatedPrompt.id, updatedPrompt);
     } catch (error) {
       console.error('Failed to update prompt:', error);
+      // Show error message to user
+      const errorMessage = error instanceof Error ? error.message : 'Failed to update prompt';
+      if (errorMessage.includes('Unauthorized')) {
+        alert('Only the prompt keeper can edit prompts.');
+      } else {
+        alert('Failed to update prompt. Please try again.');
+      }
     }
   };
 
@@ -124,6 +131,13 @@ export default function PromptKeeperPage() {
       await deletePrompt(id);
     } catch (error) {
       console.error('Failed to delete prompt:', error);
+      // Show error message to user
+      const errorMessage = error instanceof Error ? error.message : 'Failed to delete prompt';
+      if (errorMessage.includes('Unauthorized')) {
+        alert('Only the prompt keeper can delete prompts.');
+      } else {
+        alert('Failed to delete prompt. Please try again.');
+      }
     }
   };
   
@@ -259,7 +273,7 @@ export default function PromptKeeperPage() {
                     prompt={prompt}
                     onUpdatePrompt={updatePromptHandler}
                     onDeletePrompt={deletePromptHandler}
-                    isEditable={selectedScope === 'private'}
+                    isEditable={canEditPrompt(currentUser)}
                   />
                 ))}
               </div>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -12,6 +12,8 @@ import {
 } from 'firebase/database';
 import { database } from './firebase';
 import type { Prompt, User, TeamMember, Team } from './types';
+import { canEditPrompt, canDeletePrompt } from './permissions';
+import { getCurrentUser } from './auth';
 
 // Database structure:
 // /users/{userId} -> User
@@ -281,6 +283,12 @@ export async function getPrompt(promptId: string): Promise<Prompt | null> {
 }
 
 export async function updatePrompt(promptId: string, updates: Partial<Prompt>): Promise<void> {
+  // Check if current user has permission to edit prompts
+  const currentUser = await getCurrentUser();
+  if (!canEditPrompt(currentUser)) {
+    throw new Error('Unauthorized: Only the prompt keeper can edit prompts');
+  }
+
   const promptRef = ref(database, `prompts/${promptId}`);
   const snapshot = await get(promptRef);
   
@@ -291,6 +299,12 @@ export async function updatePrompt(promptId: string, updates: Partial<Prompt>): 
 }
 
 export async function deletePrompt(promptId: string): Promise<void> {
+  // Check if current user has permission to delete prompts
+  const currentUser = await getCurrentUser();
+  if (!canDeletePrompt(currentUser)) {
+    throw new Error('Unauthorized: Only the prompt keeper can delete prompts');
+  }
+
   const promptRef = ref(database, `prompts/${promptId}`);
   await remove(promptRef);
 }

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -35,3 +35,16 @@ export function canManageTeamMembers(user: User | null, targetTeamId?: string): 
   if (!user?.teamId) return false;
   return !targetTeamId || user.teamId === targetTeamId;
 }
+
+// New permission functions for prompt editing and deletion
+export function canEditPrompt(user: User | null): boolean {
+  return isSuperUser(user);
+}
+
+export function canDeletePrompt(user: User | null): boolean {
+  return isSuperUser(user);
+}
+
+export function canManagePrompts(user: User | null): boolean {
+  return isSuperUser(user);
+}


### PR DESCRIPTION
Restrict prompt editing and deletion to super users (prompt keepers).

This implements multi-layered security, including UI hiding, application-level permission checks, and server-side Firebase rules, to ensure only prompt keepers can modify or remove prompts.