### PR TITLE
Enable private team prompt sharing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,7 +46,7 @@ type SharingScope = 'private' | 'team' | 'community';
 
 const scopeData: { id: SharingScope; label: string; icon: React.ElementType; description: string; disabled?: boolean; }[] = [
   { id: 'private', label: 'My Prompt Repository', icon: UserIcon, description: 'Your personal collection. All prompts you created, regardless of sharing level.' },
-  { id: 'team', label: 'Team Repository (Coming Soon)', icon: Users, description: 'Team collaboration features are coming soon!', disabled: true },
+  { id: 'team', label: 'Team Repository', icon: Users, description: "Team prompts from your team plus community prompts." },
   { id: 'community', label: 'Community Showcase', icon: Globe, description: 'Discover prompts shared by the entire community.' },
 ];
 
@@ -131,10 +131,6 @@ export default function PromptKeeperPage() {
   };
   
   const handleScopeChange = (scope: SharingScope) => {
-    // Prevent team scope selection for now
-    if (scope === 'team') {
-      return;
-    }
     setSelectedScope(scope);
     setSelectedTag('All');
   };

--- a/src/components/prompt-card.tsx
+++ b/src/components/prompt-card.tsx
@@ -54,10 +54,14 @@ export function PromptCard({ prompt, onUpdatePrompt, onDeletePrompt, isEditable 
 
   const handleSharingChange = (isTeam: boolean) => {
     if (prompt.sharing !== 'global' && isEditable) {
-      // When changing to team sharing, ensure teamId is set
       const updates: Partial<Prompt> = {
         sharing: isTeam ? 'team' : 'private'
       };
+
+      // When enabling team sharing, ensure teamId exists on the prompt by inheriting current user's teamId
+      if (isTeam && !prompt.teamId && currentUser?.teamId) {
+        updates.teamId = currentUser.teamId;
+      }
       
       // If changing to private, we can optionally clear teamId
       if (!isTeam && prompt.teamId) {
@@ -66,7 +70,6 @@ export function PromptCard({ prompt, onUpdatePrompt, onDeletePrompt, isEditable 
       
       onUpdatePrompt({ ...prompt, ...updates });
       
-      // Show feedback to user
       toast({
         title: isTeam ? 'Copied to Team' : 'Moved to Private',
         description: isTeam ? 'Your prompt is now visible to your team.' : 'Your prompt is now private.',
@@ -140,7 +143,7 @@ export function PromptCard({ prompt, onUpdatePrompt, onDeletePrompt, isEditable 
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Coming soon</p>
+                  <p>Toggle to share with your team</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>


### PR DESCRIPTION
Activate the Team Repository UI and enable team-scoped prompt sharing.

This allows users to share prompts specifically with their team, ensuring visibility only to team members while leveraging existing backend access controls.

---
<a href="https://cursor.com/background-agent?bcId=bc-8742822a-b9f6-4dd1-b2b9-e052a9573465">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8742822a-b9f6-4dd1-b2b9-e052a9573465">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

