### PR TITLE
Restore super admin user management access

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -129,6 +129,11 @@ export async function updateUser(userId: string, updates: Partial<User>): Promis
   await update(userRef, filteredUpdates as any);
 }
 
+export async function deleteUserRecord(userId: string): Promise<void> {
+  const userRef = ref(database, `users/${userId}`);
+  await remove(userRef);
+}
+
 // Team operations
 export async function getTeamMembers(teamId: string): Promise<TeamMember[]> {
   const teamRef = ref(database, `teams/${teamId}/members`);


### PR DESCRIPTION
Migrate super admin user record to Firebase auth UID and reassert `super_user` role to restore access to all users.

The super admin was unable to see all users due to a potential mismatch between their database user record ID and their Firebase authentication UID, or an incorrect role assignment. This PR updates the super admin bootstrap flow to ensure the user record is correctly associated with the authenticated Firebase UID, reasserts the `super_user` role, and removes any legacy super admin entries to maintain data consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a852fde-9ec1-49fb-af3d-9d69157c1667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a852fde-9ec1-49fb-af3d-9d69157c1667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

