### PR TITLE
Fix Stripe webhook endpoint failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "recharts": "^2.15.1",
+        "stripe": "^17.7.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.2"
@@ -9215,6 +9216,19 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/stubs": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "recharts": "^2.15.1",
+    "stripe": "^17.7.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.2"

--- a/scripts/verify_stripe_webhook.ts
+++ b/scripts/verify_stripe_webhook.ts
@@ -1,0 +1,121 @@
+import { spawn } from "child_process";
+import Stripe from "stripe";
+
+const STRIPE_SECRET_KEY = "sk_test_dummy";
+const STRIPE_WEBHOOK_SECRET = "whsec_test_secret";
+const PORT = 9002; // Matches package.json "dev" script
+
+// Initialize Stripe
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  apiVersion: "2024-12-18.acacia" as any,
+});
+
+async function main() {
+  console.log(`Starting Next.js server on port ${PORT}...`);
+
+  const server = spawn("npm", ["run", "dev"], {
+    env: {
+      ...process.env,
+      STRIPE_SECRET_KEY,
+      STRIPE_WEBHOOK_SECRET,
+    },
+    // inherit stdio to see server logs (useful for debugging)
+    // but we can silence it if it's too much. I'll keep it for now.
+    stdio: "inherit",
+  });
+
+  // Wait for server to be ready
+  const maxRetries = 60; // Wait up to 60 seconds
+  let ready = false;
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const res = await fetch(`http://localhost:${PORT}/`);
+      if (res.ok || res.status === 404) { // 404 is fine, means server is reachable
+        ready = true;
+        break;
+      }
+    } catch (e) {
+      // ignore
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  if (!ready) {
+    console.error("Server failed to start within timeout.");
+    server.kill();
+    process.exit(1);
+  }
+
+  console.log("Server is ready. Running tests...");
+
+  try {
+    // Test 1: Valid Signature
+    const payload = JSON.stringify({
+      id: "evt_test_webhook",
+      object: "event",
+      type: "payout.paid",
+      data: {
+        object: {
+          id: "po_123",
+          object: "payout",
+          amount: 1000,
+          currency: "usd",
+        }
+      }
+    });
+
+    const header = stripe.webhooks.generateTestHeaderString({
+      payload,
+      secret: STRIPE_WEBHOOK_SECRET,
+    });
+
+    console.log("Sending valid webhook...");
+    const res1 = await fetch(`http://localhost:${PORT}/api/webhooks/stripe`, {
+      method: "POST",
+      headers: {
+        "Stripe-Signature": header,
+        "Content-Type": "application/json",
+      },
+      body: payload,
+    });
+
+    if (res1.status === 200) {
+      console.log("✅ Valid webhook test passed (200 OK)");
+    } else {
+      console.error(`❌ Valid webhook test failed. Status: ${res1.status}`);
+      const text = await res1.text();
+      console.error("Response:", text);
+      process.exitCode = 1;
+    }
+
+    // Test 2: Invalid Signature
+    console.log("Sending invalid webhook...");
+    const res2 = await fetch(`http://localhost:${PORT}/api/webhooks/stripe`, {
+      method: "POST",
+      headers: {
+        "Stripe-Signature": "t=123,v1=invalid_signature",
+        "Content-Type": "application/json",
+      },
+      body: payload,
+    });
+
+    if (res2.status === 400) {
+      console.log("✅ Invalid webhook test passed (400 Bad Request)");
+    } else {
+      console.error(`❌ Invalid webhook test failed. Status: ${res2.status}`);
+      const text = await res2.text();
+      console.error("Response:", text);
+      process.exitCode = 1;
+    }
+
+  } catch (error) {
+    console.error("Test execution failed:", error);
+    process.exitCode = 1;
+  } finally {
+    console.log("Stopping server...");
+    server.kill();
+    process.exit();
+  }
+}
+
+main();

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,64 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string || "dummy_key_for_build", {
+  apiVersion: "2024-12-18" as any,
+});
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const headerPayload = await headers();
+  const signature = headerPayload.get("Stripe-Signature");
+
+  if (!signature) {
+    console.error("Missing Stripe-Signature header");
+    return NextResponse.json({ error: "Missing Stripe-Signature header" }, { status: 400 });
+  }
+
+  if (!process.env.STRIPE_WEBHOOK_SECRET) {
+    console.error("STRIPE_WEBHOOK_SECRET is not set");
+    // Return 200 to prevent retries if it's a configuration issue on our end, or 500?
+    // User asked for 200-299.
+    // But if we can't verify, we shouldn't process.
+    // I'll return 500 so logs show failure, but maybe user wants it to succeed?
+    // The user says "You need to return any status code between HTTP 200 to 299 for Stripe to consider the webhook event successfully delivered."
+    // If I return 500, Stripe will disable it again.
+    // But I can't verify signature without the secret.
+    // I will return 500 and log clearly.
+    return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
+  }
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET
+    );
+  } catch (error: any) {
+    console.error(`Webhook signature verification failed: ${error.message}`);
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+        case "payout.paid":
+            const payout = event.data.object as Stripe.Payout;
+            console.log(`💰 Payout paid! ${payout.amount} ${payout.currency}`);
+            break;
+        case "invoice.created":
+            const invoice = event.data.object as Stripe.Invoice;
+            console.log(`🧾 Invoice created! ${invoice.id}`);
+            break;
+        default:
+            console.log(`Unhandled event type ${event.type}`);
+    }
+  } catch (error: any) {
+    console.error(`Error handling event: ${error.message}`);
+    return NextResponse.json({ error: "Error handling event" }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true }, { status: 200 });
+}


### PR DESCRIPTION
Implemented the missing Stripe webhook endpoint at `src/app/api/webhooks/stripe/route.ts`. The endpoint verifies the Stripe signature using `STRIPE_WEBHOOK_SECRET` and handles `payout.paid` and `invoice.created` events by logging them. It returns a 200 OK status code to acknowledge receipt, resolving the issue where Stripe disabled the endpoint due to failures. Added a verification script `scripts/verify_stripe_webhook.ts` to test the implementation locally.

---
*PR created automatically by Jules for task [14556293964431637719](https://jules.google.com/task/14556293964431637719) started by @BrStrategies-bg*